### PR TITLE
Fix salt#61215 ignore offline nodes

### DIFF
--- a/src/saltext/proxmox/clouds/proxmox.py
+++ b/src/saltext/proxmox/clouds/proxmox.py
@@ -417,7 +417,10 @@ def avail_locations(call=None):
     ret = {}
     for node in nodes:
         name = node["node"]
-        ret[name] = node
+        if node["status"] == "online":
+            ret[name] = node
+        else:
+            log.warning("Node %s is %s, ignoring it", name, node["status"])
 
     return ret
 


### PR DESCRIPTION
### What does this PR do?
salt-cloud --list-locations or --list-images would error out when encountering an offline node. This PR skips such nodes issuing a warning instead.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/61215