### PR TITLE
Set vmid from profile, fix gitignore for local

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,7 +138,7 @@ dmypy.json
 artifacts/
 
 # Just a dir for local whatever
-local/
+local
 
 .DS_Store
 .idea/

--- a/src/saltext/proxmox/clouds/proxmox.py
+++ b/src/saltext/proxmox/clouds/proxmox.py
@@ -693,7 +693,10 @@ def create(vm_):
                 vm_["ip_address"] = str(ip_address)
 
     try:
-        newid = _get_next_vmid()
+        if 'vmid' in vm_:
+            newid = vm_['vmid']
+        else:
+            newid = _get_next_vmid()
         data = create_node(vm_, newid)
     except Exception as exc:  # pylint: disable=broad-except
         msg = str(exc)

--- a/src/saltext/proxmox/clouds/proxmox.py
+++ b/src/saltext/proxmox/clouds/proxmox.py
@@ -693,10 +693,11 @@ def create(vm_):
                 vm_["ip_address"] = str(ip_address)
 
     try:
-        if 'vmid' in vm_:
-            newid = vm_['vmid']
+        if "vmid" in vm_:
+            newid = vm_["vmid"]
         else:
             newid = _get_next_vmid()
+
         data = create_node(vm_, newid)
     except Exception as exc:  # pylint: disable=broad-except
         msg = str(exc)


### PR DESCRIPTION
### What does this PR do?
Allow vm profile to set vmid number instead of using next available

### What issues does this PR fix or reference?
Fixes: https://github.com/salt-extensions/saltext-proxmox/issues/10

### Previous Behavior
Only settable automatically
