### PR TITLE
fix location parameter in avail_images()

### DIFF
--- a/changelog/25.fixed.md
+++ b/changelog/25.fixed.md
@@ -1,0 +1,1 @@
+fixed location parameter for avail_images()

--- a/src/saltext/proxmox/clouds/proxmox.py
+++ b/src/saltext/proxmox/clouds/proxmox.py
@@ -460,7 +460,7 @@ def avail_locations(call=None):
     return ret
 
 
-def avail_images(kwargs=None, call=None):
+def avail_images(call=None, kwargs=None):
     """
     Return a list of the images that are on the provider
 

--- a/src/saltext/proxmox/clouds/proxmox.py
+++ b/src/saltext/proxmox/clouds/proxmox.py
@@ -460,7 +460,7 @@ def avail_locations(call=None):
     return ret
 
 
-def avail_images(call=None, location="local"):
+def avail_images(kwargs=None, call=None):
     """
     Return a list of the images that are on the provider
 
@@ -469,12 +469,21 @@ def avail_images(call=None, location="local"):
     .. code-block:: bash
 
         salt-cloud --list-images my-proxmox-config
+        salt-cloud -f avail_images my-proxmox-config location="storage_location"
     """
     if call == "action":
         raise SaltCloudSystemExit(
             "The avail_images function must be called with "
             "-f or --function, or with the --list-images option"
         )
+
+    if not isinstance(kwargs, dict):
+        kwargs = {}
+
+    if "location" in kwargs:
+        location = kwargs["location"]
+    else:
+        location = "local"
 
     ret = {}
     for host_name, host_details in avail_locations().items():

--- a/tests/unit/clouds/test_proxmox.py
+++ b/tests/unit/clouds/test_proxmox.py
@@ -306,6 +306,26 @@ def test_clone_id():
         )
 
 
+def test_avail_images():
+    """
+    Test avail_images with different values for location parameter
+    """
+    with patch("saltext.proxmox.clouds.proxmox.avail_locations", return_value={"node1": {}}), patch(
+        "saltext.proxmox.clouds.proxmox.query", return_value=[]
+    ) as mock_query:
+
+        # CASE 1: location not set should default to "local"
+        proxmox.avail_images()
+        mock_query.assert_called_with("get", "nodes/{}/storage/{}/content".format("node1", "local"))
+
+        # CASE 2: location set should query location
+        kwargs = {"location": "other_storage"}
+        proxmox.avail_images(kwargs=kwargs)
+        mock_query.assert_called_with(
+            "get", "nodes/{}/storage/{}/content".format("node1", kwargs["location"])
+        )
+
+
 def test_avail_locations():
     """
     Test if the available locations make sense


### PR DESCRIPTION
### What does this PR do?
fix location parameter in avail_images()

### What issues does this PR fix or reference?
Fixes: #25

### Previous Behavior
It was previously not possible to change the location for `avail_images()` causing it to always show the images from the storage named `local`.

### New Behavior
`$ salt-cloud --function avail_images my-proxmox-config location=other_storage`  allows the location to be changed.
When omitting the `location` argument, the function will default to `local`.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
No