### PR TITLE
waiting for actual vm stop/shutdown

### DIFF
--- a/src/saltext/proxmox/clouds/proxmox.py
+++ b/src/saltext/proxmox/clouds/proxmox.py
@@ -1283,7 +1283,7 @@ def stop(name, vmid=None, call=None):
 
         log.debug('Waiting for state "stopped" for vm %s on %s', vmid, name)
         if not wait_for_state(vmid, "stopped"):
-            return {"Error": "Unable to start {}, command timed out".format(name)}
+            return {"Error": "Unable to stop {}, command timed out".format(name)}
 
     return {"Stopped": "{} was stopped.".format(name)}
 
@@ -1311,6 +1311,6 @@ def shutdown(name=None, vmid=None, call=None):
 
     log.debug('Waiting for state "stopped" for vm %s on %s', vmid, name)
     if not wait_for_state(vmid, "stopped"):
-        return {"Error": "Unable to start {}, command timed out".format(name)}
+        return {"Error": "Unable to shutdown {}, command timed out".format(name)}
 
     return {"Shutdown": "{} was shutdown.".format(name)}


### PR DESCRIPTION
### What does this PR do?
transferred from https://github.com/saltstack/salt/pull/58843/

Implements waiting for actual vm stop for proxmox cloud driver, so we can avoid race conditions when stopping/starting a VM in sequence during deployment orchestration.

This feature was missing from existing driver and marked with a TBD comment.

### What issues does this PR fix or reference?
Fixes: N/A

### Previous Behavior
When invoking 'stop' action on proxmox cloud driver, salt-cloud did not wait until the VM was actually stopped.

### New Behavior
Now the code waits until the VM is reported as stopped, or times out.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No