### PR TITLE
Fix error when LXC uses DHCP

### DIFF
--- a/src/saltext/proxmox/clouds/proxmox.py
+++ b/src/saltext/proxmox/clouds/proxmox.py
@@ -677,12 +677,13 @@ def _parse_ips(vm_config, vm_type):
     for ip_config in ip_configs:
         try:
             ip_with_netmask = _stringlist_to_dictionary(ip_config).get("ip")
-            ip = ip_interface(ip_with_netmask).ip
+            if ip_with_netmask != "dhcp":
+                ip = ip_interface(ip_with_netmask).ip
 
-            if ip.is_private:
-                private_ips.append(str(ip))
-            else:
-                public_ips.append(str(ip))
+                if ip.is_private:
+                    private_ips.append(str(ip))
+                else:
+                    public_ips.append(str(ip))
         except ValueError:
             log.error("Ignoring '%s' because it is not a valid IP", ip_with_netmask)
 


### PR DESCRIPTION
When the network configuration uses DHCP, the extension fails. This skips adding IPs for interfaces set to DHCP. According to the salt-cloud documentation, the IPs are optional.

### What does this PR do?

### What issues does this PR fix or reference?
Fixes:

### Previous Behavior
Fails and outputs an error.

### New Behavior
Skips adding the IPs to the node information.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
